### PR TITLE
Add .env example and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,15 @@ CREATE TABLE users (
 ```
 
 
-2. 서버 실행
+2. `server/.env` 파일 설정
+
+```bash
+cd server
+cp .env.example .env
+# .env 파일을 열어 실제 DB 정보와 JWT_SECRET 값을 입력하세요.
+```
+
+3. 서버 실행
 
 ```
 cd server
@@ -32,7 +40,7 @@ npm install
 npm start
 ```
 
-3. 클라이언트 실행
+4. 클라이언트 실행
 
 ```
 cd client

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,5 @@
+DB_HOST=localhost
+DB_USER=user
+DB_PASSWORD=password
+DB_NAME=board_db
+JWT_SECRET=your_jwt_secret


### PR DESCRIPTION
## Summary
- document DB credentials and JWT secret in `server/.env.example`
- update README with instructions for creating `.env`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6889b7c030cc8326ba103f17320cc4d3