### PR TITLE
Fix auth token secret and document API

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,13 @@ npm start
 ```
 
 API 서버는 `localhost:5001`, React는 `localhost:3000`에서 실행됩니다.
+
+## 주요 API 엔드포인트
+
+- `POST /api/auth/signup` - 회원 가입
+- `POST /api/auth/login` - 로그인 후 JWT 토큰 반환
+- `GET /api/posts` - 게시글 목록 조회
+- `GET /api/posts/:id` - 게시글 상세 조회
+- `POST /api/posts` - 게시글 작성 (JWT 필요)
+- `PUT /api/posts/:id` - 게시글 수정 (JWT 필요)
+- `DELETE /api/posts/:id` - 게시글 삭제 (JWT 필요)

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -29,9 +29,11 @@ router.post("/login", (req, res) => {
       const match = await bcrypt.compare(password, results[0].password);
       if (!match) return res.status(401).send("비밀번호 틀림");
 
-      const token = jwt.sign({ userId: results[0].id }, "SECRET_KEY", {
-        expiresIn: "1h",
-      });
+      const token = jwt.sign(
+        { userId: results[0].id },
+        process.env.JWT_SECRET || "SECRET_KEY",
+        { expiresIn: "1h" }
+      );
       res.json({ token });
     }
   );


### PR DESCRIPTION
## Summary
- use `JWT_SECRET` env var when creating tokens
- document API endpoints

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6889cb113b90832686cb546c5bd359c5