### PR TITLE
Add auth pages and fix JWT header usage

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,6 +4,8 @@ import PostListPage from "./pages/PostListPage";
 import PostDetailPage from "./pages/PostDetailPage";
 import PostWritePage from "./pages/PostWritePage";
 import PostEditPage from "./pages/PostEditPage";
+import LoginPage from "./pages/LoginPage";
+import SignupPage from "./pages/SignupPage";
 import "react-toastify/dist/ReactToastify.css";
 
 function App() {
@@ -15,6 +17,8 @@ function App() {
         <Route path="/post/:id" element={<PostDetailPage />} />
         <Route path="/write" element={<PostWritePage />} />
         <Route path="/edit/:id" element={<PostEditPage />} />
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/signup" element={<SignupPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/client/src/api/authApi.js
+++ b/client/src/api/authApi.js
@@ -1,0 +1,6 @@
+import axios from "axios";
+
+const API = "http://localhost:5001/api/auth";
+
+export const signup = (user) => axios.post(`${API}/signup`, user);
+export const login = (user) => axios.post(`${API}/login`, user);

--- a/client/src/api/postApi.js
+++ b/client/src/api/postApi.js
@@ -4,8 +4,8 @@ const API = "http://localhost:5001/api/posts";
 
 export const getPosts = () => axios.get(API);
 export const getPost = (id) => axios.get(`${API}/${id}`);
-export const createPost = (post) => axios.post(API, post);
-export const deletePost = (id) => axios.delete(`${API}/${id}`);
-export const updatePost = (id, post) => axios.put(`${API}/${id}`, post);
+export const createPost = (post) => axios.post(API, post, authHeader());
+export const deletePost = (id) => axios.delete(`${API}/${id}`, authHeader());
+export const updatePost = (id, post) => axios.put(`${API}/${id}`, post, authHeader());
 
 export const authHeader = () => ({ headers: { Authorization: `Bearer ${localStorage.getItem("token")}` } });

--- a/client/src/pages/LoginPage.jsx
+++ b/client/src/pages/LoginPage.jsx
@@ -1,0 +1,41 @@
+import React, { useState } from "react";
+import { useNavigate, Link } from "react-router-dom";
+import { login } from "../api/authApi";
+
+export default function LoginPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await login({ email, password });
+      localStorage.setItem("token", res.data.token);
+      navigate("/");
+    } catch (err) {
+      alert("로그인 실패");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>로그인</h2>
+      <input
+        placeholder="이메일"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <input
+        type="password"
+        placeholder="비밀번호"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button type="submit">로그인</button>
+      <p>
+        회원이 아니신가요? <Link to="/signup">회원가입</Link>
+      </p>
+    </form>
+  );
+}

--- a/client/src/pages/PostListPage.jsx
+++ b/client/src/pages/PostListPage.jsx
@@ -12,6 +12,7 @@ export default function PostListPage() {
   return (
     <div>
       <h1>게시판</h1>
+      <Link to="/login">로그인</Link>
       <Link to="/write">✍️ 글쓰기</Link>
       <ul>
         {posts.map((post) => (

--- a/client/src/pages/SignupPage.jsx
+++ b/client/src/pages/SignupPage.jsx
@@ -1,0 +1,41 @@
+import React, { useState } from "react";
+import { useNavigate, Link } from "react-router-dom";
+import { signup } from "../api/authApi";
+
+export default function SignupPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await signup({ email, password });
+      alert("회원가입 완료");
+      navigate("/login");
+    } catch (err) {
+      alert("회원가입 실패");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>회원가입</h2>
+      <input
+        placeholder="이메일"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <input
+        type="password"
+        placeholder="비밀번호"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button type="submit">가입하기</button>
+      <p>
+        이미 회원이신가요? <Link to="/login">로그인</Link>
+      </p>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- implement login and signup pages
- secure post API requests with JWT header
- expose login and signup routes in `App.jsx`
- add simple login link on list page
- add auth api helper

## Testing
- `npm test --silent` in `client` *(no tests defined)*
- `npm test --silent` in `server` *(no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_6889d667e380832691940631f305ba69