### PR TITLE
Restrict post creation to logged-in users

### DIFF
--- a/client/src/pages/PostListPage.jsx
+++ b/client/src/pages/PostListPage.jsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { getPosts } from "../api/postApi";
 
 export default function PostListPage() {
   const [posts, setPosts] = useState([]);
+  const [token, setToken] = useState(localStorage.getItem("token"));
+  const navigate = useNavigate();
 
   useEffect(() => {
     getPosts().then((res) => setPosts(res.data));
@@ -14,8 +16,22 @@ export default function PostListPage() {
       <header className="header">
         <h1>게시판</h1>
         <div className="nav-links">
-          <Link to="/login">로그인</Link>
-          <Link to="/write">✍️ 글쓰기</Link>
+          {token ? (
+            <>
+              <button
+                onClick={() => {
+                  localStorage.removeItem("token");
+                  setToken(null);
+                  navigate("/login");
+                }}
+              >
+                로그아웃
+              </button>
+              <Link to="/write">✍️ 글쓰기</Link>
+            </>
+          ) : (
+            <Link to="/login">로그인</Link>
+          )}
         </div>
       </header>
       <ul className="post-list">

--- a/client/src/pages/PostWritePage.jsx
+++ b/client/src/pages/PostWritePage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { createPost } from "../api/postApi";
 
@@ -6,6 +6,12 @@ export default function PostWritePage() {
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!localStorage.getItem("token")) {
+      navigate("/login");
+    }
+  }, [navigate]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- Hide the write-post link and provide logout when not authenticated
- Redirect unauthenticated users away from the post creation page

## Testing
- `npm test` (fails: Missing script: "test")
- `cd client && npm test` (fails: Missing script: "test")
- `cd server && npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_6891a6ec65c883269d54846e105d7393